### PR TITLE
Fix typo in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,7 +128,7 @@ Let's grab some text that's rendered by JavaScript:
 
 .. code-block:: shell
 
-    $ pipenv install requests-http[browser]
+    $ pipenv install requests-html[browser]
 
 .. code-block:: pycon
 


### PR DESCRIPTION
JS optional extra is `requests-html[browser]` not `requests-http[browser]`