### PR TITLE
UserWarning fix

### DIFF
--- a/requests_html.py
+++ b/requests_html.py
@@ -117,7 +117,7 @@ class BaseParser:
         """`lxml <http://lxml.de>`_ representation of the
         :class:`Element <Element>` or :class:`HTML <HTML>`.
         """
-        return soup_parse(self.html)
+        return soup_parse(self.html, features='html.parser')
 
     @property
     def text(self) -> _Text:


### PR DESCRIPTION
fixed UserWarning by passing default **bsargs to fromstring method in lxml. Default value for 'feature' is 'html.parser', but user can also use 'lxml' or other valid values instead.