### PR TITLE
ignore javascript links

### DIFF
--- a/requests_html.py
+++ b/requests_html.py
@@ -212,7 +212,7 @@ class BaseParser:
 
                 try:
                     href = link.attrs['href'].strip()
-                    if href and not (href.startswith('#') and self.skip_anchors and href in ['javascript:;']):
+                    if href and not (href.startswith('#') and self.skip_anchors) and not href.startswith('javascript:'):
                         yield href
                 except KeyError:
                     pass


### PR DESCRIPTION
ignore anything startswith `javascript:` in href attr

my consideration is that javascript link in href has no meaning for web scraping

before:

```
 In [1]: from requests_html import HTML

In [2]: doc = """<a href="javascript:void(0)" onclick="fn()">fn is called</a>
   ...: <a href="javascript:;" onclick="fn()">fn is called too!</a>
   ...: <a href="javascript:undifined" onclick="fn()">fn is called too!</a>
   ...: <a href="javascript: void(0)" onclick="fn()">fn is called too!</a>"""

In [3]: html = HTML(html=doc)

In [4]: html.links
Out[4]:
{'javascript: void(0)',
 'javascript:;',
 'javascript:undifined',
 'javascript:void(0)'}

In [5]: html.absolute_links
Out[5]:
{'javascript://example.org/ void(0)',
 'javascript://example.org/;',
 'javascript://example.org/undifined',
 'javascript://example.org/void(0)'}
```

after:
```
In [1]: from requests_html import HTML

In [2]: doc = """<a href="javascript:void(0)" onclick="fn()">fn is called</a>
   ...: <a href="javascript:;" onclick="fn()">fn is called too!</a>
   ...: <a href="javascript:undifined" onclick="fn()">fn is called too!</a>
   ...: <a href="javascript: void(0)" onclick="fn()">fn is called too!</a>"""

In [3]: html = HTML(html=doc)

In [4]: html.links
Out[4]: set()

In [5]: html.absolute_links
Out[5]: set()
```