### PR TITLE
Change website to Amazon Smile

### DIFF
--- a/tests/test_internet.py
+++ b/tests/test_internet.py
@@ -6,7 +6,7 @@ def test_pagination():
     pages = (
         'https://xkcd.com/1957/',
         'https://reddit.com/',
-        'https://pornhub.com/',
+        'https://smile.amazon.com/',
         'https://theverge.com/archives'
     )
 


### PR DESCRIPTION
The original choice of website could cause issues for people who run the test in a professional environment.