### PR TITLE
Fix typing

### DIFF
--- a/requests_html.py
+++ b/requests_html.py
@@ -653,6 +653,24 @@ class HTMLSession(requests.Session):
             self.headers['User-Agent'] = user_agent()
 
         self.hooks = {'response': self._handle_response}
+        
+    def get(self, *args, **kwargs) -> HTMLResponse:
+        return super(HTMLSession, self).get(*args, **kwargs)
+
+    def post(self, *args, **kwargs) -> HTMLResponse:
+        return super(HTMLSession, self).post(*args, **kwargs)
+
+    def put(self, *args, **kwargs) -> HTMLResponse:
+        return super(HTMLSession, self).post(*args, **kwargs)
+
+    def patch(self, *args, **kwargs) -> HTMLResponse:
+        return super(HTMLSession, self).post(*args, **kwargs)
+
+    def head(self, *args, **kwargs) -> HTMLResponse:
+        return super(HTMLSession, self).post(*args, **kwargs)
+
+    def options(self, *args, **kwargs) -> HTMLResponse:
+        return super(HTMLSession, self).post(*args, **kwargs)
 
     @staticmethod
     def _handle_response(response, **kwargs) -> HTMLResponse:


### PR DESCRIPTION
Requests overwrite your typing with comments:

r"""Sends a GET request. Returns :class:`Response` object.

        :param url: URL for the new :class:`Request` object.
        :param \*\*kwargs: Optional arguments that ``request`` takes.
        :rtype: requests.Response"""