### PR TITLE
Create LXML from raw_html

### DIFF
--- a/requests_html.py
+++ b/requests_html.py
@@ -146,7 +146,7 @@ class BaseParser:
         of the :class:`Element <Element>` or :class:`HTML <HTML>`.
         """
         if self._pq is None:
-            self._pq = PyQuery(self.html)
+            self._pq = PyQuery(self.lxml)
 
         return self._pq
 

--- a/requests_html.py
+++ b/requests_html.py
@@ -159,7 +159,7 @@ class BaseParser:
             try:
                 self._lxml = soup_parse(self.html, features='html.parser')
             except ValueError:
-                self._lxml = lxml.html.fromstring(self.html)
+                self._lxml = lxml.html.fromstring(self.raw_html)
 
         return self._lxml
 


### PR DESCRIPTION
Create LXML from `self.raw_html` instead of `self.html` to allow LXML to process plain XML pages as per @beda42 findings in issue https://github.com/kennethreitz/requests-html/issues/145

I have tested this change with 200 sites and it seems to fix the issue. HTML pages seem to all be working as expected. I haven't run into an issue with any that I've tested.