### PR TITLE
Add pyppeteer_args to .render()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 
 # command to install dependencies
 install:
-  - "pip install pipenv --upgrade-strategy=only-if-needed"
+  - "pip install git+https://github.com/pypa/pipenv.git"
   - "pipenv install --dev"
 
 # command to run the dependencies

--- a/requests_html.py
+++ b/requests_html.py
@@ -486,7 +486,7 @@ class HTML(BaseParser):
     def add_next_symbol(self, next_symbol):
         self.next_symbol.append(next_symbol)
 
-    def render(self, retries: int = 8, script: str = None, wait: float = 0.2, scrolldown=False, sleep: int = 0, reload: bool = True, timeout: Union[float, int] = 8.0, keep_page: bool = False):
+    def render(self, retries: int = 8, script: str = None, wait: float = 0.2, scrolldown: int = 0, sleep: int = 0, reload: bool = True, timeout: Union[float, int] = 8.0, keep_page: bool = False, pyppeteer_args: dict = None):
         """Reloads the response in Chromium, and replaces HTML content
         with an updated version, with JavaScript executed.
 
@@ -497,6 +497,7 @@ class HTML(BaseParser):
         :param sleep: Integer, if provided, of how many long to sleep after initial render.
         :param reload: If ``False``, content will not be loaded from the browser, but will be provided from memory.
         :param keep_page: If ``True`` will allow you to interact with the browser page through ``r.html.page``.
+        :param pyppeteer_args: Arguments for ``pyppeteer.launch()`` method.
 
         If ``scrolldown`` is specified, the page will scrolldown the specified
         number of times, after sleeping the specified amount of time
@@ -533,9 +534,13 @@ class HTML(BaseParser):
         Warning: the first time you run this method, it will download
         Chromium into your home directory (``~/.pyppeteer``).
         """
-        async def _async_render(*, url: str, script: str = None, scrolldown, sleep: int, wait: float, reload, content: Optional[str], timeout: Union[float, int], keep_page: bool):
+        if pyppeteer_args is None:
+            pyppeteer_args = {}
+
+        async def _async_render(*, url: str, script: str = None, scrolldown, sleep: int, wait: float, reload,
+                                content: Optional[str], timeout: Union[float, int], keep_page: bool):
             try:
-                page = await self.session.browser.newPage()
+                page = await self.session.get_browser().newPage()
 
                 # Wait before rendering the page, to prevent timeouts.
                 await asyncio.sleep(wait)
@@ -569,7 +574,7 @@ class HTML(BaseParser):
             except TimeoutError:
                 return None
 
-        self.session.browser  # Automatycally create a event loop and browser
+        self.session.get_browser(pyppeteer_args)  # Create a event loop and browser.
         content = None
 
         # Automatically set Reload to False, if example URL is being used.
@@ -673,11 +678,20 @@ class HTMLSession(requests.Session):
 
         return HTMLResponse._from_response(r, self)
 
-    @property
-    def browser(self):
+    def get_browser(self, pyppeteer_args=None):
+        if pyppeteer_args is None:
+            pyppeteer_args = {}
         if not hasattr(self, "_browser"):
             self.loop = asyncio.get_event_loop()
-            self._browser = self.loop.run_until_complete(pyppeteer.launch(headless=True, args=['--no-sandbox']))
+            browser_args = {
+                'headless': True,
+                'args': ['--no-sandbox']
+            }
+            browser_args.update(pyppeteer_args)
+            if 'browserWSEndpoint' in browser_args:
+                self._browser = self.loop.run_until_complete(pyppeteer.connect(**browser_args))
+            else:
+                self._browser = self.loop.run_until_complete(pyppeteer.launch(**browser_args))
         return self._browser
 
     def close(self):

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with io.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = '\n' + f.read()
 
+
 class UploadCommand(Command):
     """Support setup.py upload."""
 

--- a/tests/test_requests_html.py
+++ b/tests/test_requests_html.py
@@ -4,7 +4,6 @@ from functools import partial
 import pytest
 import psutil
 from pyppeteer.browser import Browser
-from pyppeteer.page import Page
 from requests_html import HTMLSession, AsyncHTMLSession, HTML
 from requests_file import FileAdapter
 
@@ -241,7 +240,7 @@ def test_browser_session():
         Note: session.close method need to be tested together with browser creation,
             since no doing that will left the browser running. """
     session = HTMLSession()
-    assert isinstance(session.browser, Browser)
+    assert isinstance(session.get_browser(), Browser)
     assert hasattr(session, "loop") == True
     session.close()
     # assert count_chromium_process() == 0


### PR DESCRIPTION
Hi Kenneth!
Thank you for your awesome libraries including this one!
I've worked with pyppeteer before and sometimes it is really necessary to pass additional arguments to it's `launch` method, e.g. - look at this my thread https://github.com/miyakogi/pyppeteer/issues/14
So I added it, also fixed CI which was broken by one bug that was fixed only in the latest github version of `pipenv` and fixed some minor code style issues;)
