### PR TITLE
Docs: Add note to install Linux packages

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -169,7 +169,7 @@ Let's grab some text that's rendered by JavaScript:
 
 Note, the first time you ever run the ``render()`` method, it will download
 Chromium into your home directory (e.g. ``~/.pyppeteer/``). This only happens
-once.
+once. You may also need to install a few `Linux packages <https://github.com/miyakogi/pyppeteer/issues/60>`_ to get pyppeteer working.
 
 Pagination
 ==========


### PR DESCRIPTION
I ran into `pyppeteer.errors.BrowserError: Failed to connect to browser port:` and after a bit of snooping found that some Linux packages needed to be installed on my machine for pyppeteer to run. Suggest to add a note to save others time. What do you think @kennethreitz?