### PR TITLE
found links should also include link/script/img tags

### DIFF
--- a/requests_html.py
+++ b/requests_html.py
@@ -292,10 +292,18 @@ class BaseParser:
         """All found links on page, in as–is form."""
 
         def gen():
-            for link in self.find('a'):
+            href_list = []
 
+            for link in self.find('a') + self.find('link'):
+                href = link.attrs.get('href', '').strip()
+                href_list.append(href)
+
+            for link in self.find('script') + self.find('img'):
+                href = link.attrs.get('src', '').strip()
+                href_list.append(href)
+
+            for href in href_list:
                 try:
-                    href = link.attrs['href'].strip()
                     if href and not (href.startswith('#') and self.skip_anchors) and not href.startswith(('javascript:', 'mailto:')):
                         yield href
                 except KeyError:


### PR DESCRIPTION
Hey, recently I developed a web crawler named [`requests-crawler`](https://github.com/debugtalk/WebCrawler/tree/requests-html), based on requests-html. 

I found out that requests-html can only extract links with `a` tag, while other tags like `link`/`script/img` are missing.

So I open this pull request, hoping this feature could be merged.

Thanks.