### PR TITLE
Multiple chromium tab fix

### DIFF
--- a/requests_html.py
+++ b/requests_html.py
@@ -567,6 +567,8 @@ class HTML(BaseParser):
                     page = None
                 return content, result, page
             except TimeoutError:
+                await page.close()
+                page = None
                 return None
 
         self.session.browser  # Automatycally create a event loop and browser


### PR DESCRIPTION
Within the render function, the page is rendered through the _async_render function. This function will try to render content by first creating a page, and currently will only close said page if the content is generated. However, if at any point there's a timeout beforehand, the current page isn't closed, and instead _async_render will be called again [as per the # assigned to retries in render()] and end up leaving behind an unused page. 

This change will enable render to close the "failed" attempt BEFORE opening a new page to try again, and should fix the issue of massive cpu buildup with multiple chromium instances. Sorry if this is messy, it's my first time using git to make a change.