### PR TITLE
Fix minor typo

### DIFF
--- a/requests_html.py
+++ b/requests_html.py
@@ -694,7 +694,7 @@ class AsyncHTMLSession(requests.Session):
                  mock_browser: bool = True, *args, **kwargs):
         """ Set or create an event loop and a thread pool.
 
-            :param loop: Asyncio lopp to use.
+            :param loop: Asyncio loop to use.
             :param workers: Amount of threads to use for executing async calls.
                 If not pass it will default to the number of processors on the
                 machine, multiplied by 5. """


### PR DESCRIPTION
lopp -> loop in init docstring of AsyncHTMLSession.