### PR TITLE
exclude html files for github linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+docs/source/_templates/hacks.html linguist-vendored=false
+docs/source/_templates/sidebarintro.html linguist-vendored=false
+docs/source/_templates/sidebarlogo.html linguist-vendored=false
+tests/python.html linguist-vendored=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,2 @@
-docs/source/_templates/hacks.html linguist-vendored=false
-docs/source/_templates/sidebarintro.html linguist-vendored=false
-docs/source/_templates/sidebarlogo.html linguist-vendored=false
-tests/python.html linguist-vendored=false
+docs/source/_templates/*.html linguist-vendored=false
+tests/*.html linguist-vendored=false


### PR DESCRIPTION
doc on method https://github.com/github/linguist#vendored-code

with this requests-html will be properly recognized as python instead of html program
