### PR TITLE
Add "tag" attribute for Element objects

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -110,6 +110,13 @@ Crab an :class:`Element <Element>`'s root tag name:
    >>> about.tag
    'li'
 
+Show the line number that an :class:`Element <Element>`'s root tag located in:
+
+.. code-block:: pycon
+
+    >>> about.lineno
+    249
+
 Select an :class:`Element <Element>` list within an :class:`Element <Element>`:
 
 .. code-block:: pycon

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -103,7 +103,12 @@ Render out an :class:`Element <Element>`'s HTML:
     >>> about.html
     '<li aria-haspopup="true" class="tier-1 element-1 " id="about">\n<a class="" href="/about/" title="">About</a>\n<ul aria-hidden="true" class="subnav menu" role="menu">\n<li class="tier-2 element-1" role="treeitem"><a href="/about/apps/" title="">Applications</a></li>\n<li class="tier-2 element-2" role="treeitem"><a href="/about/quotes/" title="">Quotes</a></li>\n<li class="tier-2 element-3" role="treeitem"><a href="/about/gettingstarted/" title="">Getting Started</a></li>\n<li class="tier-2 element-4" role="treeitem"><a href="/about/help/" title="">Help</a></li>\n<li class="tier-2 element-5" role="treeitem"><a href="http://brochure.getpython.info/" title="">Python Brochure</a></li>\n</ul>\n</li>'
 
+Crab an :class:`Element <Element>`'s root tag name:
 
+.. code-block:: pycon
+
+   >>> about.tag
+   'li'
 
 Select an :class:`Element <Element>` list within an :class:`Element <Element>`:
 

--- a/requests_html.py
+++ b/requests_html.py
@@ -379,6 +379,7 @@ class Element(BaseParser):
         super(Element, self).__init__(element=element, url=url, default_encoding=default_encoding)
         self.element = element
         self.tag = element.tag
+        self.lineno = element.sourceline
         self._attrs = None
 
     def __repr__(self) -> str:

--- a/requests_html.py
+++ b/requests_html.py
@@ -378,6 +378,7 @@ class Element(BaseParser):
     def __init__(self, *, element, url: _URL, default_encoding: _DefaultEncoding = None) -> None:
         super(Element, self).__init__(element=element, url=url, default_encoding=default_encoding)
         self.element = element
+        self.tag = element.tag
         self._attrs = None
 
     def __repr__(self) -> str:


### PR DESCRIPTION
The (top level node's) tag name for the Element object is frequently used (at least, for Web code analysis), it should be grabbed more conveniently.
