### PR TITLE
Added ignoreHTTPErrors parameter

### DIFF
--- a/requests_html.py
+++ b/requests_html.py
@@ -645,7 +645,7 @@ class HTMLSession(requests.Session):
     amongst other things.
     """
 
-    def __init__(self, mock_browser=True):
+    def __init__(self, mock_browser=True, ignoreHTTPSErrors=False):
         super(HTMLSession, self).__init__()
 
         # Mock a web browser's user agent.
@@ -653,6 +653,7 @@ class HTMLSession(requests.Session):
             self.headers['User-Agent'] = user_agent()
 
         self.hooks = {'response': self._handle_response}
+        self.ignoreHTTPSErrors = ignoreHTTPSErrors
 
     @staticmethod
     def _handle_response(response, **kwargs) -> HTMLResponse:
@@ -677,7 +678,7 @@ class HTMLSession(requests.Session):
     def browser(self):
         if not hasattr(self, "_browser"):
             self.loop = asyncio.get_event_loop()
-            self._browser = self.loop.run_until_complete(pyppeteer.launch(headless=True, args=['--no-sandbox']))
+            self._browser = self.loop.run_until_complete(pyppeteer.launch(ignoreHTTPSErrors=self.ignoreHTTPSErrors, headless=True, args=['--no-sandbox']))
         return self._browser
 
     def close(self):


### PR DESCRIPTION
The library doesn't allow to _render_ a page with a not valid SSL certificate even if [pypeeteer](https://github.com/miyakogi/pyppeteer) provides the parameter `ignoreHTTPSErrors`.

I just added a new default argument to the `__init__` function of the class `HTMLSession` that has been passed to `pyppeteer`.