### PR TITLE
Fix absolute_links for hrefs without a path component

### DIFF
--- a/requests_html.py
+++ b/requests_html.py
@@ -349,17 +349,7 @@ class BaseParser:
             if result:
                 return result
 
-        # Parse the url to separate out the path
-        parsed = urlparse(self.url)._asdict()
-
-        # Remove any part of the path after the last '/'
-        parsed['path'] = '/'.join(parsed['path'].split('/')[:-1]) + '/'
-
-        # Reconstruct the url with the modified path
-        parsed = (v for v in parsed.values())
-        url = urlunparse(parsed)
-
-        return url
+        return self.url
 
 
 class Element(BaseParser):

--- a/tests/test_requests_html.py
+++ b/tests/test_requests_html.py
@@ -155,6 +155,8 @@ def test_anchor_links():
     ('http://example.com/foo/', 'test.html', 'http://example.com/foo/test.html'),
     ('http://example.com/foo/bar', 'test.html', 'http://example.com/foo/test.html'),
     ('http://example.com/foo/', '/test.html', 'http://example.com/test.html'),
+    ('http://example.com/foo.html', '?test=val', 'http://example.com/foo.html?test=val'),
+    ('http://example.com/foo/?some=var', 'test.html', 'http://example.com/foo/test.html'),
     ('http://example.com/', 'http://xkcd.com/about/', 'http://xkcd.com/about/'),
     ('http://example.com/', '//xkcd.com/about/', 'http://xkcd.com/about/'),
 ])


### PR DESCRIPTION
The `base_url` of a page is actually the full URL including the last bit of the path.
You can test this in your JavaScript console with typing `document.baseURI`, for example here https://docs.python.org/3/library/urllib.parse.html

The result includes the filename:

![image](https://user-images.githubusercontent.com/88278/44363853-b3642f00-a4c5-11e8-8264-54cda56694a1.png)

This fixes #213 