### PR TITLE
Set verify default value to True

### DIFF
--- a/requests_html.py
+++ b/requests_html.py
@@ -688,7 +688,7 @@ class BaseSession(requests.Session):
     amongst other things.
     """
 
-    def __init__(self, mock_browser : bool = True, verify : bool = False,
+    def __init__(self, mock_browser : bool = True, verify : bool = True,
                  browser_args : list = ['--no-sandbox']):
         super().__init__()
 


### PR DESCRIPTION
I set the `verify` default value to True like requests library.