### PR TITLE
exclude non-http uri schemes from BaseParser.links()

### DIFF
--- a/requests_html.py
+++ b/requests_html.py
@@ -296,7 +296,7 @@ class BaseParser:
 
                 try:
                     href = link.attrs['href'].strip()
-                    if href and not (href.startswith('#') and self.skip_anchors) and not href.startswith(('javascript:', 'mailto:')):
+                    if href and not (href.startswith('#') and self.skip_anchors) and href.startswith('http'):
                         yield href
                 except KeyError:
                     pass


### PR DESCRIPTION
Rather than creating piecemeal exclusions for non-standard schemes like `mailto:` and `javascript:`, assume that a true link starts with http.

Since `mailto:` is here, I figure this makes some sense... do people really want `tel:1231231337` in their links any more than `mailto:`? Same logic probably applies for a lot of the wacky non-standard schemes around these days.

Could make this logic conditional with a new property similar to `self.skip_anchors`. Said new property would default to True, ideally, IMO.

Certainly open to discussion on this!