### PR TITLE
Add support for using preinstalled copy of Chromium

### DIFF
--- a/requests_html.py
+++ b/requests_html.py
@@ -689,7 +689,7 @@ class BaseSession(requests.Session):
     """
 
     def __init__(self, mock_browser : bool = True, verify : bool = True,
-                 browser_args : list = ['--no-sandbox']):
+                 browser_args : list = ['--no-sandbox'], executable_path : str = ''):
         super().__init__()
 
         # Mock a web browser's user agent.
@@ -698,6 +698,9 @@ class BaseSession(requests.Session):
 
         self.hooks['response'].append(self.response_hook)
         self.verify = verify
+
+        if executable_path:
+            self.executable_path = executable_path
 
         self.__browser_args = browser_args
 
@@ -711,7 +714,10 @@ class BaseSession(requests.Session):
     @property
     async def browser(self):
         if not hasattr(self, "_browser"):
-            self._browser = await pyppeteer.launch(ignoreHTTPSErrors=not(self.verify), headless=True, args=self.__browser_args)
+            if self.executable_path:
+                self._browser = await pyppeteer.launch(ignoreHTTPSErrors=not(self.verify), executablePath=self.executable_path, headless=True, args=self.__browser_args)
+            else:
+                self._browser = await pyppeteer.launch(ignoreHTTPSErrors=not(self.verify), headless=True, args=self.__browser_args)
 
         return self._browser
 


### PR DESCRIPTION
In a microservice-oriented, I'd like to minimize my container startup time and reduce my container size by:
1. Eliminating the need to download Chromium on first run
2. Using a very small, lightweight container image, such as Alpine Linux

The first issue is solved by downloading Chromium as part of my own Dockerfile. The second issue presents a problem when attempting to download Chromium on-the-fly. As best I can tell, some compilation issues (musl vs glibc) prevent Chromium from playing nice on Alpine (https://github.com/GoogleChrome/puppeteer/issues/379). Workaround here (https://github.com/miyakogi/pyppeteer/issues/79), essentially BYOChromium.

This PR adds support for BYOC by adding the kwarg `executable_path` to `BaseSession`. If no value supplied, behaves as normal. If value supplied, passes it to `pyppeteer.launch()`