### PR TITLE
Fix: fstring formatted with bytes

### DIFF
--- a/requests_html.py
+++ b/requests_html.py
@@ -416,9 +416,9 @@ class HTML(BaseParser):
         if isinstance(html, str):
             html = html.encode(DEFAULT_ENCODING)
 
+        pq = PyQuery(html)
         super(HTML, self).__init__(
-            # Convert unicode HTML to bytes.
-            element=PyQuery(html)('html') or PyQuery(f'<html>{html}</html>')('html'),
+            element=pq('html') or pq.wrapAll('<html></html>')('html'),
             html=html,
             url=url,
             default_encoding=default_encoding

--- a/tests/test_requests_html.py
+++ b/tests/test_requests_html.py
@@ -173,6 +173,15 @@ def test_absolute_links(url, link, expected):
     assert html.absolute_links.pop() == expected
 
 
+@pytest.mark.parser
+def test_parser():
+    doc = """<a href='https://httpbin.org'>httpbin.org\n</a>"""
+    html = HTML(html=doc)
+
+    assert html.find('html')
+    assert html.element('a').text().strip() == 'httpbin.org'
+
+
 @pytest.mark.render
 def test_render():
     r = get()


### PR DESCRIPTION
this causes double-escaped, related issue #268

```
In [3]: hello=b"<span>hello\n  world \n</span>"

In [4]: f'<html>{hello}</html>'
Out[4]: "<html>b'<span>hello\\n  world \\n</span>'</html>"
```
