### PR TITLE
Change 'bs4' dependency to 'beautifulsoup4'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ VERSION = '0.10.0'
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    'requests', 'pyquery', 'fake-useragent', 'parse', 'bs4', 'w3lib', 'pyppeteer>=0.0.14'
+    'requests', 'pyquery', 'fake-useragent', 'parse', 'beautifulsoup4', 'w3lib', 'pyppeteer>=0.0.14'
 ]
 
 # The rest you shouldn't have to touch too much :)


### PR DESCRIPTION
'bs4' is just a dummy package to make it easier to install.  'beautifulsoup4' is the real package name.  Downstream packagers like Anaconda and Linux distributions will have 'beautifulsoup4' available, but not 'bs4', making it harder to install this package.