### PR TITLE
Add a wait_until option to render

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,5 @@ venv.bak/
 
 # Visual Studio Code 
 .vscode
+.idea
+*.iml

--- a/requests_html.py
+++ b/requests_html.py
@@ -500,7 +500,7 @@ class HTML(BaseParser):
     def add_next_symbol(self, next_symbol):
         self.next_symbol.append(next_symbol)
 
-    async def _async_render(self, *, url: str, script: str = None, scrolldown, sleep: int, wait: float, reload, content: Optional[str], timeout: Union[float, int], keep_page: bool, cookies: list = [{}]):
+    async def _async_render(self, *, url: str, script: str = None, scrolldown, sleep: int, wait: float, reload, content: Optional[str], timeout: Union[float, int], wait_until: Union[str,List[str]], keep_page: bool, cookies: list = [{}]):
         """ Handle page creation and js rendering. Internal use for render/arender methods. """
         try:
             page = await self.browser.newPage()
@@ -513,11 +513,15 @@ class HTML(BaseParser):
                     if cookie:
                         await page.setCookie(cookie)
 
+            options = {'timeout': int(timeout * 1000)}
+            if wait_until is not None:
+                options['waitUntil'] = wait_until
+
             # Load the given page (GET request, obviously.)
             if reload:
-                await page.goto(url, options={'timeout': int(timeout * 1000)})
+                await page.goto(url, options=options)
             else:
-                await page.goto(f'data:text/html,{self.html}', options={'timeout': int(timeout * 1000)})
+                await page.goto(f'data:text/html,{self.html}', options=options)
 
             result = None
             if script:
@@ -598,7 +602,7 @@ class HTML(BaseParser):
                 cookies_render.append(self._convert_cookiejar_to_render(cookie))
         return cookies_render
 
-    def render(self, retries: int = 8, script: str = None, wait: float = 0.2, scrolldown=False, sleep: int = 0, reload: bool = True, timeout: Union[float, int] = 8.0, keep_page: bool = False, cookies: list = [{}], send_cookies_session: bool = False):
+    def render(self, retries: int = 8, script: str = None, wait: float = 0.2, scrolldown=False, sleep: int = 0, reload: bool = True, timeout: Union[float, int] = 8.0, wait_until: Union[str, List[str]] = None, keep_page: bool = False, cookies: list = [{}], send_cookies_session: bool = False):
         """Reloads the response in Chromium, and replaces HTML content
         with an updated version, with JavaScript executed.
 
@@ -608,6 +612,8 @@ class HTML(BaseParser):
         :param scrolldown: Integer, if provided, of how many times to page down.
         :param sleep: Integer, if provided, of how many long to sleep after initial render.
         :param reload: If ``False``, content will not be loaded from the browser, but will be provided from memory.
+        :param timeout: Timeout for rendering, in seconds.
+        :param wait_until: When to consider the page loaded. Acceptable values are: ``load`` (default) ``domcontentloaded``, ``networkidle0``, ``networkidle1``.
         :param keep_page: If ``True`` will allow you to interact with the browser page through ``r.html.page``.
 
         :param send_cookies_session: If ``True`` send ``HTMLSession.cookies`` convert.
@@ -660,7 +666,7 @@ class HTML(BaseParser):
             if not content:
                 try:
 
-                    content, result, page = self.session.loop.run_until_complete(self._async_render(url=self.url, script=script, sleep=sleep, wait=wait, content=self.html, reload=reload, scrolldown=scrolldown, timeout=timeout, keep_page=keep_page, cookies=cookies))
+                    content, result, page = self.session.loop.run_until_complete(self._async_render(url=self.url, script=script, sleep=sleep, wait=wait, content=self.html, reload=reload, scrolldown=scrolldown, timeout=timeout, wait_until=wait_until, keep_page=keep_page, cookies=cookies))
                 except TypeError:
                     pass
             else:
@@ -674,7 +680,7 @@ class HTML(BaseParser):
         self.page = page
         return result
 
-    async def arender(self, retries: int = 8, script: str = None, wait: float = 0.2, scrolldown=False, sleep: int = 0, reload: bool = True, timeout: Union[float, int] = 8.0, keep_page: bool = False, cookies: list = [{}], send_cookies_session: bool = False):
+    async def arender(self, retries: int = 8, script: str = None, wait: float = 0.2, scrolldown=False, sleep: int = 0, reload: bool = True, timeout: Union[float, int] = 8.0, wait_until: Union[str, List[str]] = None, keep_page: bool = False, cookies: list = [{}], send_cookies_session: bool = False):
         """ Async version of render. Takes same parameters. """
 
         self.browser = await self.session.browser
@@ -691,7 +697,7 @@ class HTML(BaseParser):
             if not content:
                 try:
 
-                    content, result, page = await self._async_render(url=self.url, script=script, sleep=sleep, wait=wait, content=self.html, reload=reload, scrolldown=scrolldown, timeout=timeout, keep_page=keep_page, cookies=cookies)
+                    content, result, page = await self._async_render(url=self.url, script=script, sleep=sleep, wait=wait, content=self.html, reload=reload, scrolldown=scrolldown, timeout=timeout, wait_until=wait_until, keep_page=keep_page, cookies=cookies)
                 except TypeError:
                     pass
             else:

--- a/tests/test_internet.py
+++ b/tests/test_internet.py
@@ -46,3 +46,10 @@ def test_async_run():
 
     assert len(r) == 3
     assert isinstance(r[0], HTMLResponse)
+
+def test_wait_until(event_loop):
+    session = HTMLSession()
+
+    r = session.get('https://reddit.com/')
+    r.html.render(wait_until='networkidle0')
+    assert True


### PR DESCRIPTION
Pyppeteer's `goto` method has a very useful option, `waitUntil`, that let's you wait for one or more events (see [the documentation](https://miyakogi.github.io/pyppeteer/reference.html#pyppeteer.page.Page.goto)). This is especially useful for pages like twitter, which load 90% of the content of the page from AJAX requests. 

The default `waitUntil` is currently set to load, so `Page.goto` returns as soon as the page is loaded. Thus, in many cases, the DOM doesn't have time to change and the rendering is basically a slowest version of `get`.

In this pull request, I added an optional `wait_until` argument. If set to None (the default), then the defaut Pyppeteer behavior will prevail. For heavy AJAX sites, I recommend passing `wait_until='networkidle0'` to the `(a)render` method..