### PR TITLE
Minor update index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,7 +43,7 @@ Installation
     $ pipenv install requests-html
     ✨🍰✨
 
-Only **Python 3.6** is supported.
+Only **Python 3.6** and above is supported.
 
 
 Tutorial & Usage


### PR DESCRIPTION
Add **and above** to "only python 3.6 is supported"

I was confused originally when I read the docs and saw that only a specific version was supported. Updated to match what is in the top level readme