### PR TITLE
Proxies parameter in BaseSession __init__

### DIFF
--- a/requests_html.py
+++ b/requests_html.py
@@ -693,7 +693,6 @@ class HTML(BaseParser):
 
                     content, result, page = await self._async_render(url=self.url, script=script, sleep=sleep, wait=wait, content=self.html, reload=reload, scrolldown=scrolldown, timeout=timeout, keep_page=keep_page, cookies=cookies)
                 except TypeError:
-                    print("TEST")
                     pass
             else:
                 break

--- a/requests_html.py
+++ b/requests_html.py
@@ -693,6 +693,7 @@ class HTML(BaseParser):
 
                     content, result, page = await self._async_render(url=self.url, script=script, sleep=sleep, wait=wait, content=self.html, reload=reload, scrolldown=scrolldown, timeout=timeout, keep_page=keep_page, cookies=cookies)
                 except TypeError:
+                    print("TEST")
                     pass
             else:
                 break
@@ -757,7 +758,7 @@ class BaseSession(requests.Session):
     """
 
     def __init__(self, mock_browser : bool = True, verify : bool = True,
-                 browser_args : list = ['--no-sandbox']):
+                 browser_args : list = ['--no-sandbox'], proxies=None):
         super().__init__()
 
         # Mock a web browser's user agent.
@@ -766,7 +767,7 @@ class BaseSession(requests.Session):
 
         self.hooks['response'].append(self.response_hook)
         self.verify = verify
-
+        self.proxies = proxies or {}
         self.__browser_args = browser_args
 
 


### PR DESCRIPTION
Due to #345 I noticed that user can't use proxy. In requests proxy is used as following `requests.get(URL, proxies={})` so we need to have `proxies` attribute in `BaseSession`.