### PR TITLE
Add Pyppeteer Args to Session Init

### DIFF
--- a/requests_html.py
+++ b/requests_html.py
@@ -757,7 +757,7 @@ class BaseSession(requests.Session):
     """
 
     def __init__(self, mock_browser : bool = True, verify : bool = True,
-                 browser_args : list = ['--no-sandbox']):
+                 browser_args : list = ['--no-sandbox'], pyppeteer_args : dict = None):
         super().__init__()
 
         # Mock a web browser's user agent.
@@ -768,6 +768,7 @@ class BaseSession(requests.Session):
         self.verify = verify
 
         self.__browser_args = browser_args
+        self.__pyppeteer_args = pyppeteer_args
 
 
     def response_hook(self, response, **kwargs) -> HTMLResponse:
@@ -778,8 +779,14 @@ class BaseSession(requests.Session):
 
     @property
     async def browser(self):
+        browser_args = {
+            'headless': True,
+            'args': self.__browser_args
+        }
+        browser_args.update(self.__pyppeteer_args)
+
         if not hasattr(self, "_browser"):
-            self._browser = await pyppeteer.launch(ignoreHTTPSErrors=not(self.verify), headless=True, args=self.__browser_args)
+            self._browser = await pyppeteer.launch(ignoreHTTPSErrors=not(self.verify), **browser_args)
 
         return self._browser
 

--- a/requests_html.py
+++ b/requests_html.py
@@ -757,7 +757,7 @@ class BaseSession(requests.Session):
     """
 
     def __init__(self, mock_browser : bool = True, verify : bool = True,
-                 browser_args : list = ['--no-sandbox'], pyppeteer_args : dict = None):
+                 browser_args : list = ['--no-sandbox'], pyppeteer_args : dict = {}):
         super().__init__()
 
         # Mock a web browser's user agent.


### PR DESCRIPTION
Why
---

- Developers need the ability to set all of the pyppeteer args when
instantiating a session. This way they can set their own executable path
when running in a container, RaspberryPi, etc.

How
---

- Add pyppeteer args as a dict to the BaseSession init method.
- Use the browser args and pyppeteer args to launch pyppeteer.

Related PRs
-----------

- #270

Related Issues
---------------

- #387 