### PR TITLE
solve a simple chinese messy code problem

### DIFF
--- a/requests_html.py
+++ b/requests_html.py
@@ -669,7 +669,7 @@ class HTML(BaseParser):
         if not content:
             raise MaxRetries("Unable to render the page. Try increasing timeout")
 
-        html = HTML(url=self.url, html=content.encode(DEFAULT_ENCODING), default_encoding=DEFAULT_ENCODING)
+        html = HTML(url=self.url, html=content.encode(self.encoding), default_encoding=DEFAULT_ENCODING)
         self.__dict__.update(html.__dict__)
         self.page = page
         return result
@@ -700,7 +700,7 @@ class HTML(BaseParser):
         if not content:
             raise MaxRetries("Unable to render the page. Try increasing timeout")
 
-        html = HTML(url=self.url, html=content.encode(DEFAULT_ENCODING), default_encoding=DEFAULT_ENCODING)
+        html = HTML(url=self.url, html=content.encode(self.encoding), default_encoding=DEFAULT_ENCODING)
         self.__dict__.update(html.__dict__)
         self.page = page
         return result


### PR DESCRIPTION
When using r.html.render(), the html which regenerates by render() is using DEFAULT_ENCODING(utf-8). But if the html contains chinese, the html.text will show chinese messy code. 
Replace the DEFAULT_ENCODING in "html = HTML(url=self.url, html=content.encode(DEFAULT_ENCODING)..." with "self.encoding" will solve this problem.
So does the method "arender".