### PR TITLE
Close stucked browser page in case pyppeteer introduces NavigationTimeoutError

### DIFF
--- a/requests_html.py
+++ b/requests_html.py
@@ -539,7 +539,7 @@ class HTML(BaseParser):
                 await page.close()
                 page = None
             return content, result, page
-        except TimeoutError:
+        except (TimeoutError, pyppeteer.errors.TimeoutError):
             await page.close()
             page = None
             return None


### PR DESCRIPTION
I realized that when pyppeteer introduced NavigationTimeoutError, regarding chromium page process remains open, and they are no longer accessible from the scope. Thus, memory and CPU usage increase and it produces slowness. My eventual purpose to find the root cause of this NavigationTimeoutError but with this PR, at least we are able to close regarding browser page for now.