### PR TITLE
Edit Javascript async example

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -211,7 +211,7 @@ Or you can do this async also:
 
 .. code-block:: pycon
 
-    >>> r = asession.get('http://python-requests.org/')
+    >>> r = await asession.get('http://python-requests.org/')
 
     >>> await r.html.arender()
 


### PR DESCRIPTION
The javascript async example doesn't match the async session example using await for getting the url.