### PR TITLE
Location of pyppeteer downloaded Chromium changed in v0.0.20

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -228,7 +228,7 @@ Or you can do this async also:
 The rest of the code operates the same way as the synchronous version except that ``results`` is a list containing multiple response objects however the same basic processes can be applied as above to extract the data you want. 
 
 Note, the first time you ever run the ``render()`` method, it will download
-Chromium into your home directory (e.g. ``~/.pyppeteer/``). This only happens
+Chromium into your home directory (e.g. ``~/.local/share/pyppeteer/``). This only happens
 once.
 
 Using without Requests

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -219,7 +219,7 @@ Or you can do this async also:
     '<time>25</time>'
 
 Note, the first time you ever run the ``render()`` method, it will download
-Chromium into your home directory (e.g. ``~/.pyppeteer/``). This only happens
+Chromium into your home directory (e.g. ``~/.local/share/pyppeteer/``). This only happens
 once. You may also need to install a few `Linux packages <https://github.com/miyakogi/pyppeteer/issues/60>`_ to get pyppeteer working.
 
 Pagination

--- a/requests_html.py
+++ b/requests_html.py
@@ -643,7 +643,7 @@ class HTML(BaseParser):
             {'width': 800, 'height': 600, 'deviceScaleFactor': 1}
 
         Warning: the first time you run this method, it will download
-        Chromium into your home directory (``~/.pyppeteer``).
+        Chromium into your home directory (``~/.local/share/pyppeteer``).
         """
 
         self.browser = self.session.browser  # Automatically create a event loop and browser


### PR DESCRIPTION
> Change browser download location and temporary user data directory to:
> 
> * If `$PYPPETEER_HOME` environment variable is defined, use this location.
> * Otherwise, use platform dependent locations, based on appdirs:
>   * `'C:\Users\<username>\AppData\Local\pyppeteer'` (Windows)
>   * `'/Users/<username>/Library/Application Support/pyppeteer'` (OS X)
>   * `'/home/<username>/.local/share/pyppeteer'` (Linux)
>   * or in `'$XDG_DATA_HOME/pyppeteer'` if `$XDG_DATA_HOME` is defined

See https://github.com/pyppeteer/pyppeteer/blob/0.0.20/CHANGES.md#version-0020-2018-08-11

On my test system:

```
# ls -l ~/.local/share/pyppeteer/local-chromium/
total 4
drwxrwxr-x 3 patrick patrick 4096 Oct  8 14:23 588429
```