### PR TITLE
Add 'kwargs' to browser launch function

### DIFF
--- a/requests_html.py
+++ b/requests_html.py
@@ -757,7 +757,7 @@ class BaseSession(requests.Session):
     """
 
     def __init__(self, mock_browser : bool = True, verify : bool = True,
-                 browser_args : list = ['--no-sandbox']):
+                 browser_args : list = ['--no-sandbox'], **browser_kwargs):
         super().__init__()
 
         # Mock a web browser's user agent.
@@ -767,6 +767,7 @@ class BaseSession(requests.Session):
         self.hooks['response'].append(self.response_hook)
         self.verify = verify
 
+        self.__browser_kwargs = browser_kwargs
         self.__browser_args = browser_args
 
 
@@ -779,7 +780,7 @@ class BaseSession(requests.Session):
     @property
     async def browser(self):
         if not hasattr(self, "_browser"):
-            self._browser = await pyppeteer.launch(ignoreHTTPSErrors=not(self.verify), headless=True, args=self.__browser_args)
+            self._browser = await pyppeteer.launch(ignoreHTTPSErrors=not(self.verify), headless=True, args=self.__browser_args, **self.__browser_kwargs)
 
         return self._browser
 


### PR DESCRIPTION
When working with the project, I had encountered a small issue where I had to pass specific kwargs to the browser's launch function.

I had to pass the following kwargs to the function:
handleSIGINT=False
handleSIGTERM=False
handleSIGHUP=False 

I had to do this because I tried to call 'arender' in a seperate thread.

So I added the feature myself. 