### PR TITLE
docs: Fix a few typos

### DIFF
--- a/requests_html.py
+++ b/requests_html.py
@@ -771,7 +771,7 @@ class BaseSession(requests.Session):
 
 
     def response_hook(self, response, **kwargs) -> HTMLResponse:
-        """ Change response enconding and replace it by a HTMLResponse. """
+        """ Change response encoding and replace it by a HTMLResponse. """
         if not response.encoding:
             response.encoding = DEFAULT_ENCODING
         return HTMLResponse._from_response(response, self)

--- a/tests/test_requests_html.py
+++ b/tests/test_requests_html.py
@@ -290,7 +290,7 @@ async def test_bare_js_async_eval():
 
 
 def test_browser_session():
-    """ Test browser instaces is created and properly close when session is closed.
+    """ Test browser instances is created and properly close when session is closed.
         Note: session.close method need to be tested together with browser creation,
             since no doing that will left the browser running. """
     session = HTMLSession()


### PR DESCRIPTION
There are small typos in:
- requests_html.py
- tests/test_requests_html.py

Fixes:
- Should read `instances` rather than `instaces`.
- Should read `encoding` rather than `enconding`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md