### PR TITLE
Fix: only Python 3.6 AND ABOVE is supported

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,7 +43,7 @@ Installation
     $ pipenv install requests-html
     ✨🍰✨
 
-Only **Python 3.6** is supported.
+Only **Python 3.6 and above** is supported.
 
 
 Tutorial & Usage


### PR DESCRIPTION
Reflected the requirement:
pyhon**>**=3.6