### PR TITLE
Fix the return order of AsyncHTMLSession.run

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,10 +62,8 @@ Try async and get some sites at the same time:
     ...     print(result.html.url)
     ... 
     https://www.python.org/
-    https://www.google.com/
     https://www.reddit.com/
-
-Note that the order of the objects in the results list represents the order they were returned in, not the order that the coroutines are passed to the ``run`` method, which is shown in the example by the order being different. 
+    https://www.google.com/
 
 Grab a list of all links on the page, as–is (anchors excluded):
 

--- a/requests_html.py
+++ b/requests_html.py
@@ -839,5 +839,5 @@ class AsyncHTMLSession(BaseSession):
         tasks = [
             asyncio.ensure_future(coro()) for coro in coros
         ]
-        done, _ = self.loop.run_until_complete(asyncio.wait(tasks))
-        return [t.result() for t in done]
+        _, _ = self.loop.run_until_complete(asyncio.wait(tasks))
+        return [t.result() for t in tasks]


### PR DESCRIPTION
Fixes #480 
Stack Overflow question: [AsyncHTMLSession returns responses list disorderly! How to sort or make list ordered?](https://stackoverflow.com/q/75313454/8601760)

`done` is a `set`, which is unordered.

Since `AsyncHTMLSession.run` calls `run_until_complete(...)`, all `tasks` are in `done`, so we can just iterate `tasks`.

# This change is backward-compatible.

`done` is not in the order of completion, unlike [`asyncio.as_completed`](https://docs.python.org/3/library/asyncio-task.html#asyncio.as_completed), so there is no loss of information in this change.

From https://github.com/python/cpython/blob/4cc63e0/Lib/asyncio/tasks.py#L535-L541:

</blockquote>

```py
    done, pending = set(), set()
    for f in fs:
        if f.done():
            done.add(f)
        else:
            pending.add(f)
    return done, pending
```
</blockquote>

where `fs = set(tasks)`.