### PR TITLE
Adding __aenter__ and __aexit__ Methods to AsyncHTMLSession

### DIFF
--- a/requests_html.py
+++ b/requests_html.py
@@ -1,19 +1,20 @@
 import sys
 import asyncio
+import pyppeteer
+import requests
+import http.cookiejar
+import lxml
+
+from typing import Set, Union, List, MutableMapping, Optional
+
 from urllib.parse import urlparse, urlunparse, urljoin
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures._base import TimeoutError
 from functools import partial
-from typing import Set, Union, List, MutableMapping, Optional
-
-import pyppeteer
-import requests
-import http.cookiejar
 from pyquery import PyQuery
 
 from fake_useragent import UserAgent
 from lxml.html.clean import Cleaner
-import lxml
 from lxml import etree
 from lxml.html import HtmlElement
 from lxml.html import tostring as lxml_html_tostring
@@ -771,7 +772,6 @@ class BaseSession(requests.Session):
 
         self.__browser_args = browser_args
 
-
     def response_hook(self, response, **kwargs) -> HTMLResponse:
         """ Change response encoding and replace it by a HTMLResponse. """
         if not response.encoding:
@@ -822,6 +822,12 @@ class AsyncHTMLSession(BaseSession):
 
         self.loop = loop or asyncio.get_event_loop()
         self.thread_pool = ThreadPoolExecutor(max_workers=workers)
+
+    async def __aenter__(self) -> 'AsyncHTMLSession':
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.close()
 
     def request(self, *args, **kwargs):
         """ Partial original request func and run it in a thread. """

--- a/tests/test_requests_html.py
+++ b/tests/test_requests_html.py
@@ -1,9 +1,9 @@
 import os
+import pytest
+
 from functools import partial
 
-import pytest
 from pyppeteer.browser import Browser
-from pyppeteer.page import Page
 from requests_html import HTMLSession, AsyncHTMLSession, HTML
 from requests_file import FileAdapter
 
@@ -322,3 +322,14 @@ async def test_async_browser_session():
     browser = await session.browser
     assert isinstance(browser, Browser)
     await session.close()
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager():
+    async with AsyncHTMLSession() as s:
+        try:
+            results = await s.get('https://www.google.com')
+            assert results.status_code == 200
+        except ConnectionError:
+            # if the user has no connection skip this test
+            pass

--- a/tests/test_requests_html.py
+++ b/tests/test_requests_html.py
@@ -326,6 +326,17 @@ async def test_async_browser_session():
 
 @pytest.mark.asyncio
 async def test_async_context_manager():
+    """
+    Test the behavior of the async context manager for AsyncHTMLSession.
+
+    This test case validates that the AsyncHTMLSession instance can be used
+    as an asynchronous context manager, and the session can successfully make
+    an HTTP GET request within the context.
+
+    Note: If the user has no connection, a ConnectionError may occur, and the
+    test will be skipped.
+
+    """
     async with AsyncHTMLSession() as s:
         try:
             results = await s.get('https://www.google.com')


### PR DESCRIPTION
### Changes Overview

- Added `__aenter__` method, returning the instance of `AsyncHTMLSession` within an asynchronous context.
- Added `__aexit__` method, ensuring proper closing of the session upon context exit.
- Created a new test suite (`test_async_context_manager`) to validate the functionality of the async context manager.
- Added test case to the test suite to ensure that the session can successfully make an HTTP GET request within the async context.

### Description

This merge request introduces the addition of `__aenter__` and `__aexit__` methods to the `AsyncHTMLSession` class, providing support for using the class as an asynchronous context manager. Additionally, a test suite has been created to verify the functionality of the async context manager. Also, some imports have been moved to better align with PEP 8 – style guide.

### Motivation

The introduction of the `__aenter__` and `__aexit__` methods allows users of the `AsyncHTMLSession` class to easily manage the lifecycle of the session within an asynchronous context. The `__aenter__` method returns the instance itself, enabling seamless integration with asynchronous context management. On the other hand, the `__aexit__` method ensures that the session is properly closed when exiting the context.

### Test Results

The new test suite (`test_async_context_manager`) has been executed successfully, validating the behavior of the async context manager. The test case confirms that the `AsyncHTMLSession` instance can be used within an asynchronous context to make an HTTP GET request, and the session is properly closed upon exiting the context.

